### PR TITLE
Composer update with 23 changes 2022-06-22

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.227.1",
+            "version": "3.228.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "dd3271b171cd83dfcfa3cfc390057114d8f010b1"
+                "reference": "4ff51d01da43aa3bd36eef921a9cd4e0ff843fab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/dd3271b171cd83dfcfa3cfc390057114d8f010b1",
-                "reference": "dd3271b171cd83dfcfa3cfc390057114d8f010b1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4ff51d01da43aa3bd36eef921a9cd4e0ff843fab",
+                "reference": "4ff51d01da43aa3bd36eef921a9cd4e0ff843fab",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.227.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.228.0"
             },
-            "time": "2022-06-20T18:14:17+00:00"
+            "time": "2022-06-21T18:13:25+00:00"
         },
         {
             "name": "brick/math",
@@ -1609,16 +1609,16 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
-                "reference": "20f7b35c7208503f6c550e5ecffcd0c2c15ce446"
+                "reference": "38069b77a55231a78790c74d40b9c4d05d9c10f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/broadcasting/zipball/20f7b35c7208503f6c550e5ecffcd0c2c15ce446",
-                "reference": "20f7b35c7208503f6c550e5ecffcd0c2c15ce446",
+                "url": "https://api.github.com/repos/illuminate/broadcasting/zipball/38069b77a55231a78790c74d40b9c4d05d9c10f7",
+                "reference": "38069b77a55231a78790c74d40b9c4d05d9c10f7",
                 "shasum": ""
             },
             "require": {
@@ -1662,20 +1662,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-06T15:20:36+00:00"
+            "time": "2022-06-10T18:58:33+00:00"
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
-                "reference": "405a2d6858fc2e19d576c1844d08bd9e77a10ad9"
+                "reference": "14060207ad684e6ea29b9ff3f349813d1d2a2a0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/bus/zipball/405a2d6858fc2e19d576c1844d08bd9e77a10ad9",
-                "reference": "405a2d6858fc2e19d576c1844d08bd9e77a10ad9",
+                "url": "https://api.github.com/repos/illuminate/bus/zipball/14060207ad684e6ea29b9ff3f349813d1d2a2a0a",
+                "reference": "14060207ad684e6ea29b9ff3f349813d1d2a2a0a",
                 "shasum": ""
             },
             "require": {
@@ -1715,11 +1715,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-04-26T14:45:19+00:00"
+            "time": "2022-06-15T06:56:01+00:00"
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1779,16 +1779,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "5aac36506247e4f0e50afe815ba711c16e65bcef"
+                "reference": "239c9274b8008fb9532ada0899365d1e182f8f9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/5aac36506247e4f0e50afe815ba711c16e65bcef",
-                "reference": "5aac36506247e4f0e50afe815ba711c16e65bcef",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/239c9274b8008fb9532ada0899365d1e182f8f9d",
+                "reference": "239c9274b8008fb9532ada0899365d1e182f8f9d",
                 "shasum": ""
             },
             "require": {
@@ -1830,11 +1830,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-30T13:16:45+00:00"
+            "time": "2022-06-19T21:41:21+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1880,7 +1880,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1928,16 +1928,16 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
-                "reference": "c88c5fed551c5a8886ec4cd6155e910674539d2a"
+                "reference": "cee0a961c773a391821f370a20d28b109bfda3c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/console/zipball/c88c5fed551c5a8886ec4cd6155e910674539d2a",
-                "reference": "c88c5fed551c5a8886ec4cd6155e910674539d2a",
+                "url": "https://api.github.com/repos/illuminate/console/zipball/cee0a961c773a391821f370a20d28b109bfda3c7",
+                "reference": "cee0a961c773a391821f370a20d28b109bfda3c7",
                 "shasum": ""
             },
             "require": {
@@ -1984,11 +1984,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-07T15:08:40+00:00"
+            "time": "2022-06-17T02:14:11+00:00"
         },
         {
             "name": "illuminate/container",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -2039,16 +2039,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "e354ef98f3c59e5c8b5ba87299999220270f3da5"
+                "reference": "e014cf88ef46065b8b1f078893c01189b95ffb11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/e354ef98f3c59e5c8b5ba87299999220270f3da5",
-                "reference": "e354ef98f3c59e5c8b5ba87299999220270f3da5",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/e014cf88ef46065b8b1f078893c01189b95ffb11",
+                "reference": "e014cf88ef46065b8b1f078893c01189b95ffb11",
                 "shasum": ""
             },
             "require": {
@@ -2083,20 +2083,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-04-28T13:05:07+00:00"
+            "time": "2022-06-07T19:28:00+00:00"
         },
         {
             "name": "illuminate/database",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "3ecfa322a958b03197560964afd8d7fb201d667b"
+                "reference": "c4b2f95044d568d01cdd13bab6d52a6ef82d2835"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/3ecfa322a958b03197560964afd8d7fb201d667b",
-                "reference": "3ecfa322a958b03197560964afd8d7fb201d667b",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/c4b2f95044d568d01cdd13bab6d52a6ef82d2835",
+                "reference": "c4b2f95044d568d01cdd13bab6d52a6ef82d2835",
                 "shasum": ""
             },
             "require": {
@@ -2151,11 +2151,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-07T14:46:41+00:00"
+            "time": "2022-06-21T14:34:39+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -2210,16 +2210,16 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "fd8963dddcb053b918bd1d851eccb887180a2c83"
+                "reference": "0a73863f90e905d1d5053108fa2a270b2ec6fb0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/fd8963dddcb053b918bd1d851eccb887180a2c83",
-                "reference": "fd8963dddcb053b918bd1d851eccb887180a2c83",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/0a73863f90e905d1d5053108fa2a270b2ec6fb0f",
+                "reference": "0a73863f90e905d1d5053108fa2a270b2ec6fb0f",
                 "shasum": ""
             },
             "require": {
@@ -2233,7 +2233,7 @@
             "suggest": {
                 "ext-ftp": "Required to use the Flysystem FTP driver.",
                 "illuminate/http": "Required for handling uploaded files (^7.0).",
-                "league/flysystem": "Required to use the Flysystem local driver (^3.0).",
+                "league/flysystem": "Required to use the Flysystem local driver (^3.0.16).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.0).",
                 "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.0).",
                 "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.0).",
@@ -2268,20 +2268,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-31T14:47:24+00:00"
+            "time": "2022-06-20T16:41:48+00:00"
         },
         {
             "name": "illuminate/http",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
-                "reference": "0c00c3bdd5d3fdc712712bcd01195d607ca3b50c"
+                "reference": "8062927c38cbf4042fb2152a10f7d037affd468a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/http/zipball/0c00c3bdd5d3fdc712712bcd01195d607ca3b50c",
-                "reference": "0c00c3bdd5d3fdc712712bcd01195d607ca3b50c",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/8062927c38cbf4042fb2152a10f7d037affd468a",
+                "reference": "8062927c38cbf4042fb2152a10f7d037affd468a",
                 "shasum": ""
             },
             "require": {
@@ -2327,11 +2327,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-06T15:07:47+00:00"
+            "time": "2022-06-19T21:41:21+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2377,16 +2377,16 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
-                "reference": "83f3a404d02219afd7c40ef84d043d08320790f9"
+                "reference": "38b7cf8e25893615135fae6c699f9b1b53f909df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/mail/zipball/83f3a404d02219afd7c40ef84d043d08320790f9",
-                "reference": "83f3a404d02219afd7c40ef84d043d08320790f9",
+                "url": "https://api.github.com/repos/illuminate/mail/zipball/38b7cf8e25893615135fae6c699f9b1b53f909df",
+                "reference": "38b7cf8e25893615135fae6c699f9b1b53f909df",
                 "shasum": ""
             },
             "require": {
@@ -2435,20 +2435,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-18T15:50:08+00:00"
+            "time": "2022-06-09T07:18:56+00:00"
         },
         {
             "name": "illuminate/notifications",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
-                "reference": "0a2be5fb443988346f911cf2a41b6b6aa2ef3d71"
+                "reference": "7f05b472722952a0862ec053560990696775ecbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/notifications/zipball/0a2be5fb443988346f911cf2a41b6b6aa2ef3d71",
-                "reference": "0a2be5fb443988346f911cf2a41b6b6aa2ef3d71",
+                "url": "https://api.github.com/repos/illuminate/notifications/zipball/7f05b472722952a0862ec053560990696775ecbe",
+                "reference": "7f05b472722952a0862ec053560990696775ecbe",
                 "shasum": ""
             },
             "require": {
@@ -2493,20 +2493,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-01T14:12:13+00:00"
+            "time": "2022-06-13T18:36:23+00:00"
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
-                "reference": "6d448699cc440cfe7696d65c62313ef2a02961b1"
+                "reference": "e0be3f3f79f8235ad7334919ca4094d5074e02f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/pipeline/zipball/6d448699cc440cfe7696d65c62313ef2a02961b1",
-                "reference": "6d448699cc440cfe7696d65c62313ef2a02961b1",
+                "url": "https://api.github.com/repos/illuminate/pipeline/zipball/e0be3f3f79f8235ad7334919ca4094d5074e02f6",
+                "reference": "e0be3f3f79f8235ad7334919ca4094d5074e02f6",
                 "shasum": ""
             },
             "require": {
@@ -2541,20 +2541,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-02-28T17:10:42+00:00"
+            "time": "2022-06-09T14:13:53+00:00"
         },
         {
             "name": "illuminate/queue",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
-                "reference": "627376c7ca78c756eb890fbb50cbb0f21f6ce55d"
+                "reference": "7a0707b3817f63aecea60c7183aa3d420985b645"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/queue/zipball/627376c7ca78c756eb890fbb50cbb0f21f6ce55d",
-                "reference": "627376c7ca78c756eb890fbb50cbb0f21f6ce55d",
+                "url": "https://api.github.com/repos/illuminate/queue/zipball/7a0707b3817f63aecea60c7183aa3d420985b645",
+                "reference": "7a0707b3817f63aecea60c7183aa3d420985b645",
                 "shasum": ""
             },
             "require": {
@@ -2606,20 +2606,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-25T14:26:24+00:00"
+            "time": "2022-06-21T14:34:39+00:00"
         },
         {
             "name": "illuminate/session",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
-                "reference": "9096180db6a1195e50c13afb3db2035915b52628"
+                "reference": "3a4a350d36031a3e3314c958466e109b99af75b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/session/zipball/9096180db6a1195e50c13afb3db2035915b52628",
-                "reference": "9096180db6a1195e50c13afb3db2035915b52628",
+                "url": "https://api.github.com/repos/illuminate/session/zipball/3a4a350d36031a3e3314c958466e109b99af75b1",
+                "reference": "3a4a350d36031a3e3314c958466e109b99af75b1",
                 "shasum": ""
             },
             "require": {
@@ -2662,20 +2662,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-04-22T18:57:23+00:00"
+            "time": "2022-06-13T18:34:31+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "6ba42086f450e113d0e8830495ff474bc60bc745"
+                "reference": "07b158210af5aaca51049c8e87606046ae6573e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/6ba42086f450e113d0e8830495ff474bc60bc745",
-                "reference": "6ba42086f450e113d0e8830495ff474bc60bc745",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/07b158210af5aaca51049c8e87606046ae6573e2",
+                "reference": "07b158210af5aaca51049c8e87606046ae6573e2",
                 "shasum": ""
             },
             "require": {
@@ -2731,20 +2731,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-07T15:09:32+00:00"
+            "time": "2022-06-21T14:08:45+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
-                "reference": "e050d72d314e16492ec08401b295a214adf2d7ee"
+                "reference": "40a22d3726be4d98da507d887d1c78e68e249314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/testing/zipball/e050d72d314e16492ec08401b295a214adf2d7ee",
-                "reference": "e050d72d314e16492ec08401b295a214adf2d7ee",
+                "url": "https://api.github.com/repos/illuminate/testing/zipball/40a22d3726be4d98da507d887d1c78e68e249314",
+                "reference": "40a22d3726be4d98da507d887d1c78e68e249314",
                 "shasum": ""
             },
             "require": {
@@ -2789,20 +2789,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-24T14:00:57+00:00"
+            "time": "2022-06-13T18:36:23+00:00"
         },
         {
             "name": "illuminate/view",
-            "version": "v9.17.0",
+            "version": "v9.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
-                "reference": "dea48b6f93933a941fd6313e5229d56038c5165e"
+                "reference": "7a82bca7f1869a35be0cf9a8db5b4f16c540f3d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/view/zipball/dea48b6f93933a941fd6313e5229d56038c5165e",
-                "reference": "dea48b6f93933a941fd6313e5229d56038c5165e",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/7a82bca7f1869a35be0cf9a8db5b4f16c540f3d3",
+                "reference": "7a82bca7f1869a35be0cf9a8db5b4f16c540f3d3",
                 "shasum": ""
             },
             "require": {
@@ -2843,7 +2843,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-31T14:53:10+00:00"
+            "time": "2022-06-15T07:05:00+00:00"
         },
         {
             "name": "jolicode/jolinotif",


### PR DESCRIPTION
  - Upgrading aws/aws-sdk-php (3.227.1 => 3.228.0)
  - Upgrading illuminate/broadcasting (v9.17.0 => v9.18.0)
  - Upgrading illuminate/bus (v9.17.0 => v9.18.0)
  - Upgrading illuminate/cache (v9.17.0 => v9.18.0)
  - Upgrading illuminate/collections (v9.17.0 => v9.18.0)
  - Upgrading illuminate/conditionable (v9.17.0 => v9.18.0)
  - Upgrading illuminate/config (v9.17.0 => v9.18.0)
  - Upgrading illuminate/console (v9.17.0 => v9.18.0)
  - Upgrading illuminate/container (v9.17.0 => v9.18.0)
  - Upgrading illuminate/contracts (v9.17.0 => v9.18.0)
  - Upgrading illuminate/database (v9.17.0 => v9.18.0)
  - Upgrading illuminate/events (v9.17.0 => v9.18.0)
  - Upgrading illuminate/filesystem (v9.17.0 => v9.18.0)
  - Upgrading illuminate/http (v9.17.0 => v9.18.0)
  - Upgrading illuminate/macroable (v9.17.0 => v9.18.0)
  - Upgrading illuminate/mail (v9.17.0 => v9.18.0)
  - Upgrading illuminate/notifications (v9.17.0 => v9.18.0)
  - Upgrading illuminate/pipeline (v9.17.0 => v9.18.0)
  - Upgrading illuminate/queue (v9.17.0 => v9.18.0)
  - Upgrading illuminate/session (v9.17.0 => v9.18.0)
  - Upgrading illuminate/support (v9.17.0 => v9.18.0)
  - Upgrading illuminate/testing (v9.17.0 => v9.18.0)
  - Upgrading illuminate/view (v9.17.0 => v9.18.0)
