### PR TITLE
Composer update with 24 changes 2022-09-14

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.235.6",
+            "version": "3.235.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "d7c649ff9d55eb8099cac97c5a37a5ed2720d06b"
+                "reference": "0f5d86c0dbed9b413cae6b77c4b5811bb857c9cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d7c649ff9d55eb8099cac97c5a37a5ed2720d06b",
-                "reference": "d7c649ff9d55eb8099cac97c5a37a5ed2720d06b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0f5d86c0dbed9b413cae6b77c4b5811bb857c9cb",
+                "reference": "0f5d86c0dbed9b413cae6b77c4b5811bb857c9cb",
                 "shasum": ""
             },
             "require": {
@@ -86,6 +86,7 @@
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^1.10.22",
+                "dms/phpunit-arraysubset-asserts": "^0.4.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
@@ -93,10 +94,11 @@
                 "ext-sockets": "*",
                 "nette/neon": "^2.3",
                 "paragonie/random_compat": ">= 2",
-                "phpunit/phpunit": "^4.8.35 || ^5.6.3",
+                "phpunit/phpunit": "^4.8.35 || ^5.6.3 || ^9.5",
                 "psr/cache": "^1.0",
                 "psr/simple-cache": "^1.0",
-                "sebastian/comparator": "^1.2.3"
+                "sebastian/comparator": "^1.2.3 || ^4.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "suggest": {
                 "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
@@ -144,9 +146,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.235.6"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.235.7"
             },
-            "time": "2022-09-12T18:15:48+00:00"
+            "time": "2022-09-13T18:19:11+00:00"
         },
         {
             "name": "brick/math",
@@ -281,16 +283,16 @@
         },
         {
             "name": "discord-php/http",
-            "version": "v9.1.5",
+            "version": "v9.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/discord-php/DiscordPHP-Http.git",
-                "reference": "02b2f301ad4f62b883b884d9c283e7625b384a46"
+                "reference": "e4465626d9baa39092d71ad7af37f131516f6cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/discord-php/DiscordPHP-Http/zipball/02b2f301ad4f62b883b884d9c283e7625b384a46",
-                "reference": "02b2f301ad4f62b883b884d9c283e7625b384a46",
+                "url": "https://api.github.com/repos/discord-php/DiscordPHP-Http/zipball/e4465626d9baa39092d71ad7af37f131516f6cf9",
+                "reference": "e4465626d9baa39092d71ad7af37f131516f6cf9",
                 "shasum": ""
             },
             "require": {
@@ -326,9 +328,9 @@
             "description": "Handles HTTP requests to Discord servers",
             "support": {
                 "issues": "https://github.com/discord-php/DiscordPHP-Http/issues",
-                "source": "https://github.com/discord-php/DiscordPHP-Http/tree/v9.1.5"
+                "source": "https://github.com/discord-php/DiscordPHP-Http/tree/v9.1.6"
             },
-            "time": "2022-09-09T11:25:59+00:00"
+            "time": "2022-09-13T10:12:44+00:00"
         },
         {
             "name": "discord/interactions",
@@ -1565,7 +1567,7 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
@@ -1623,7 +1625,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1676,7 +1678,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1736,16 +1738,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "f2d62ebe609b7c7ff40685ec15db9c48b585910b"
+                "reference": "75c6da8dae581e37943ddc864a8fc6830fae9065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/f2d62ebe609b7c7ff40685ec15db9c48b585910b",
-                "reference": "f2d62ebe609b7c7ff40685ec15db9c48b585910b",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/75c6da8dae581e37943ddc864a8fc6830fae9065",
+                "reference": "75c6da8dae581e37943ddc864a8fc6830fae9065",
                 "shasum": ""
             },
             "require": {
@@ -1787,11 +1789,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-07T13:10:58+00:00"
+            "time": "2022-09-12T13:46:55+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1837,7 +1839,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1885,16 +1887,16 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
-                "reference": "1459f231ba8733ae1334e3b16371a4f321348a6e"
+                "reference": "0b627ee1deb9f9d99ea116918ddad2f694bc038e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/console/zipball/1459f231ba8733ae1334e3b16371a4f321348a6e",
-                "reference": "1459f231ba8733ae1334e3b16371a4f321348a6e",
+                "url": "https://api.github.com/repos/illuminate/console/zipball/0b627ee1deb9f9d99ea116918ddad2f694bc038e",
+                "reference": "0b627ee1deb9f9d99ea116918ddad2f694bc038e",
                 "shasum": ""
             },
             "require": {
@@ -1943,11 +1945,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-08T20:26:04+00:00"
+            "time": "2022-09-13T13:29:20+00:00"
         },
         {
             "name": "illuminate/container",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1998,7 +2000,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -2046,16 +2048,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "0fa89ac98042b3eb26d9d78ef0d408e0719246cb"
+                "reference": "dacbcadf6575380afeef670277ce718b3e6c7e06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/0fa89ac98042b3eb26d9d78ef0d408e0719246cb",
-                "reference": "0fa89ac98042b3eb26d9d78ef0d408e0719246cb",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/dacbcadf6575380afeef670277ce718b3e6c7e06",
+                "reference": "dacbcadf6575380afeef670277ce718b3e6c7e06",
                 "shasum": ""
             },
             "require": {
@@ -2110,20 +2112,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-08T14:12:13+00:00"
+            "time": "2022-09-12T15:32:50+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
-                "reference": "2dea521665d295f6cefef78f1b5abeea6b94e35f"
+                "reference": "0b23463b45e25c9e46288a549b6582ce134cd068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/events/zipball/2dea521665d295f6cefef78f1b5abeea6b94e35f",
-                "reference": "2dea521665d295f6cefef78f1b5abeea6b94e35f",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/0b23463b45e25c9e46288a549b6582ce134cd068",
+                "reference": "0b23463b45e25c9e46288a549b6582ce134cd068",
                 "shasum": ""
             },
             "require": {
@@ -2165,20 +2167,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-02T13:59:45+00:00"
+            "time": "2022-09-12T14:09:45+00:00"
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "de91c9c61c69f39783e706e20de6ef9254d5d8e1"
+                "reference": "2579700c62f5eb767305759d5b31da6697462096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/de91c9c61c69f39783e706e20de6ef9254d5d8e1",
-                "reference": "de91c9c61c69f39783e706e20de6ef9254d5d8e1",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/2579700c62f5eb767305759d5b31da6697462096",
+                "reference": "2579700c62f5eb767305759d5b31da6697462096",
                 "shasum": ""
             },
             "require": {
@@ -2227,20 +2229,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-05T14:29:16+00:00"
+            "time": "2022-09-13T13:42:06+00:00"
         },
         {
             "name": "illuminate/http",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
-                "reference": "74e8df08f71bdba3285fa7e1d959ca74722d8928"
+                "reference": "04f479013bcca27b28d4e6949792a047869f59bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/http/zipball/74e8df08f71bdba3285fa7e1d959ca74722d8928",
-                "reference": "74e8df08f71bdba3285fa7e1d959ca74722d8928",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/04f479013bcca27b28d4e6949792a047869f59bf",
+                "reference": "04f479013bcca27b28d4e6949792a047869f59bf",
                 "shasum": ""
             },
             "require": {
@@ -2286,11 +2288,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-09T13:55:09+00:00"
+            "time": "2022-09-12T14:38:50+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2336,7 +2338,7 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
@@ -2398,16 +2400,16 @@
         },
         {
             "name": "illuminate/notifications",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
-                "reference": "e360d51938e8b594be42b0d8edd85f1454e94e50"
+                "reference": "98d1e4e7966d267a3b59198a537eea05b074e028"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/notifications/zipball/e360d51938e8b594be42b0d8edd85f1454e94e50",
-                "reference": "e360d51938e8b594be42b0d8edd85f1454e94e50",
+                "url": "https://api.github.com/repos/illuminate/notifications/zipball/98d1e4e7966d267a3b59198a537eea05b074e028",
+                "reference": "98d1e4e7966d267a3b59198a537eea05b074e028",
                 "shasum": ""
             },
             "require": {
@@ -2452,11 +2454,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-08-24T14:57:26+00:00"
+            "time": "2022-09-12T13:48:14+00:00"
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -2504,7 +2506,7 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
@@ -2569,7 +2571,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -2625,16 +2627,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "fff7e3659a137ff254d9930bb16c0559f49033af"
+                "reference": "df3b4ad1f4d3cda0ee0d9172cb8f9fc1dc7e9b25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/fff7e3659a137ff254d9930bb16c0559f49033af",
-                "reference": "fff7e3659a137ff254d9930bb16c0559f49033af",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/df3b4ad1f4d3cda0ee0d9172cb8f9fc1dc7e9b25",
+                "reference": "df3b4ad1f4d3cda0ee0d9172cb8f9fc1dc7e9b25",
                 "shasum": ""
             },
             "require": {
@@ -2690,11 +2692,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-09T13:56:49+00:00"
+            "time": "2022-09-12T19:07:18+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -2752,7 +2754,7 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v9.29.0",
+            "version": "v9.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",


### PR DESCRIPTION
  - Upgrading aws/aws-sdk-php (3.235.6 => 3.235.7)
  - Upgrading discord-php/http (v9.1.5 => v9.1.6)
  - Upgrading illuminate/broadcasting (v9.29.0 => v9.30.0)
  - Upgrading illuminate/bus (v9.29.0 => v9.30.0)
  - Upgrading illuminate/cache (v9.29.0 => v9.30.0)
  - Upgrading illuminate/collections (v9.29.0 => v9.30.0)
  - Upgrading illuminate/conditionable (v9.29.0 => v9.30.0)
  - Upgrading illuminate/config (v9.29.0 => v9.30.0)
  - Upgrading illuminate/console (v9.29.0 => v9.30.0)
  - Upgrading illuminate/container (v9.29.0 => v9.30.0)
  - Upgrading illuminate/contracts (v9.29.0 => v9.30.0)
  - Upgrading illuminate/database (v9.29.0 => v9.30.0)
  - Upgrading illuminate/events (v9.29.0 => v9.30.0)
  - Upgrading illuminate/filesystem (v9.29.0 => v9.30.0)
  - Upgrading illuminate/http (v9.29.0 => v9.30.0)
  - Upgrading illuminate/macroable (v9.29.0 => v9.30.0)
  - Upgrading illuminate/mail (v9.29.0 => v9.30.0)
  - Upgrading illuminate/notifications (v9.29.0 => v9.30.0)
  - Upgrading illuminate/pipeline (v9.29.0 => v9.30.0)
  - Upgrading illuminate/queue (v9.29.0 => v9.30.0)
  - Upgrading illuminate/session (v9.29.0 => v9.30.0)
  - Upgrading illuminate/support (v9.29.0 => v9.30.0)
  - Upgrading illuminate/testing (v9.29.0 => v9.30.0)
  - Upgrading illuminate/view (v9.29.0 => v9.30.0)
