### PR TITLE
Composer update with 23 changes 2022-10-05

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.237.2",
+            "version": "3.238.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "6027eb8b9316d208537fba1c12e53e379a4574b6"
+                "reference": "f55a1f9e34e45d87628937f04bba170fe56015bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6027eb8b9316d208537fba1c12e53e379a4574b6",
-                "reference": "6027eb8b9316d208537fba1c12e53e379a4574b6",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f55a1f9e34e45d87628937f04bba170fe56015bb",
+                "reference": "f55a1f9e34e45d87628937f04bba170fe56015bb",
                 "shasum": ""
             },
             "require": {
@@ -146,9 +146,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.237.2"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.238.0"
             },
-            "time": "2022-10-03T18:15:06+00:00"
+            "time": "2022-10-04T18:18:02+00:00"
         },
         {
             "name": "brick/math",
@@ -1567,7 +1567,7 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
@@ -1625,7 +1625,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1678,7 +1678,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1738,7 +1738,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1793,7 +1793,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1839,7 +1839,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1887,7 +1887,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1949,7 +1949,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -2000,7 +2000,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -2048,16 +2048,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "bbfc48604ce871248f75b82a27c8a88fc827ffe8"
+                "reference": "d6880620eecac4c0e1882c59889e58191232967c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/bbfc48604ce871248f75b82a27c8a88fc827ffe8",
-                "reference": "bbfc48604ce871248f75b82a27c8a88fc827ffe8",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/d6880620eecac4c0e1882c59889e58191232967c",
+                "reference": "d6880620eecac4c0e1882c59889e58191232967c",
                 "shasum": ""
             },
             "require": {
@@ -2112,11 +2112,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-29T13:31:14+00:00"
+            "time": "2022-10-03T15:39:23+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -2171,7 +2171,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -2233,7 +2233,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
@@ -2292,7 +2292,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2338,7 +2338,7 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
@@ -2400,7 +2400,7 @@
         },
         {
             "name": "illuminate/notifications",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
@@ -2458,7 +2458,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -2506,7 +2506,7 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
@@ -2571,7 +2571,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -2627,16 +2627,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "9c46abb8707ba30bd60142d8fd2e2f86e3d1f016"
+                "reference": "c5eeb30bbeb1f505938be61cb70ef614451ee446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/9c46abb8707ba30bd60142d8fd2e2f86e3d1f016",
-                "reference": "9c46abb8707ba30bd60142d8fd2e2f86e3d1f016",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/c5eeb30bbeb1f505938be61cb70ef614451ee446",
+                "reference": "c5eeb30bbeb1f505938be61cb70ef614451ee446",
                 "shasum": ""
             },
             "require": {
@@ -2693,11 +2693,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-30T06:19:24+00:00"
+            "time": "2022-10-03T14:55:35+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -2755,16 +2755,16 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v9.33.0",
+            "version": "v9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
-                "reference": "dc036c550b6e165ac07b6c8039d946461c9766c2"
+                "reference": "cb2b28be0178bc3ede35e4559e927ed6e2904f0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/view/zipball/dc036c550b6e165ac07b6c8039d946461c9766c2",
-                "reference": "dc036c550b6e165ac07b6c8039d946461c9766c2",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/cb2b28be0178bc3ede35e4559e927ed6e2904f0d",
+                "reference": "cb2b28be0178bc3ede35e4559e927ed6e2904f0d",
                 "shasum": ""
             },
             "require": {
@@ -2805,7 +2805,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-09-21T15:39:13+00:00"
+            "time": "2022-10-03T13:27:53+00:00"
         },
         {
             "name": "jolicode/jolinotif",


### PR DESCRIPTION
  - Upgrading aws/aws-sdk-php (3.237.2 => 3.238.0)
  - Upgrading illuminate/broadcasting (v9.33.0 => v9.34.0)
  - Upgrading illuminate/bus (v9.33.0 => v9.34.0)
  - Upgrading illuminate/cache (v9.33.0 => v9.34.0)
  - Upgrading illuminate/collections (v9.33.0 => v9.34.0)
  - Upgrading illuminate/conditionable (v9.33.0 => v9.34.0)
  - Upgrading illuminate/config (v9.33.0 => v9.34.0)
  - Upgrading illuminate/console (v9.33.0 => v9.34.0)
  - Upgrading illuminate/container (v9.33.0 => v9.34.0)
  - Upgrading illuminate/contracts (v9.33.0 => v9.34.0)
  - Upgrading illuminate/database (v9.33.0 => v9.34.0)
  - Upgrading illuminate/events (v9.33.0 => v9.34.0)
  - Upgrading illuminate/filesystem (v9.33.0 => v9.34.0)
  - Upgrading illuminate/http (v9.33.0 => v9.34.0)
  - Upgrading illuminate/macroable (v9.33.0 => v9.34.0)
  - Upgrading illuminate/mail (v9.33.0 => v9.34.0)
  - Upgrading illuminate/notifications (v9.33.0 => v9.34.0)
  - Upgrading illuminate/pipeline (v9.33.0 => v9.34.0)
  - Upgrading illuminate/queue (v9.33.0 => v9.34.0)
  - Upgrading illuminate/session (v9.33.0 => v9.34.0)
  - Upgrading illuminate/support (v9.33.0 => v9.34.0)
  - Upgrading illuminate/testing (v9.33.0 => v9.34.0)
  - Upgrading illuminate/view (v9.33.0 => v9.34.0)
